### PR TITLE
Use better markdown parser and html purifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fork CMS Module: Forum
 
-Depends on the profiles module and [markdown package by dflydev](https://github.com/dflydev/dflydev-markdown).
+Depends on the profiles module and [php-markdown package by michelf](https://github.com/michelf/php-markdown).
 
 ## Importent note
 

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,6 @@
     "homepage": "http://www.fork-cms.com/",
     "license": "MIT",
     "require": {
-        "dflydev/markdown": "1.0.*"
+        "michelf/php-markdown": "1.4.*"
     }
 }

--- a/frontend/modules/forum/engine/post.php
+++ b/frontend/modules/forum/engine/post.php
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-use dflydev\markdown\MarkdownParser;
+use \Michelf\Markdown;
 
 /**
  * In this file we store all generic functions that we will be using to get and set post information.
@@ -169,8 +169,26 @@ class FrontendForumPost
 	{
 		if($parseMarkdown)
 		{
-			$parser = new MarkdownParser();
-			return $parser->transformMarkdown(htmlentities($this->text));
+			// Transform markdown to html
+			$content = Markdown::defaultTransform($this->text);
+
+			// Purify the html to avoid XSS
+			$config = HTMLPurifier_Config::createDefault();
+			$config->set('Core.Encoding', 'UTF-8');
+			$config->set('HTML.Doctype', 'XHTML 1.0 Transitional');
+			$config->set('Cache.DefinitionImpl', null);
+			$config->set('Core.EscapeInvalidTags', true);
+
+			// Set allowed html tags (based on stackoverflow whitelist)
+			$config->set(
+				'HTML.Allowed',
+				'a[href|title],b,strong,blockquote[cite],code,del,dd,dl,dt,em,h1,h2,h3,h4,h5,h6,i,li,ol,p,pre,s,sup,sub,strong,strike,ul,br,hr,
+				img[src|alt|title]'
+			);
+
+			$purifier = new HTMLPurifier($config);
+
+			return $purifier->purify($content);
 		}
 
 		return $this->text;

--- a/frontend/modules/forum/engine/topic.php
+++ b/frontend/modules/forum/engine/topic.php
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-use dflydev\markdown\MarkdownParser;
+use \Michelf\Markdown;
 
 /**
  * In this file we store all generic functions that we will be using to get and set topic information.
@@ -283,8 +283,26 @@ class FrontendForumTopic
 	{
 		if($parseMarkdown)
 		{
-			$parser = new MarkdownParser();
-			return $parser->transformMarkdown(htmlentities($this->text));
+			// Transform markdown to html
+			$content = Markdown::defaultTransform($this->text);
+
+			// Purify the html to avoid XSS
+			$config = HTMLPurifier_Config::createDefault();
+			$config->set('Core.Encoding', 'UTF-8');
+			$config->set('HTML.Doctype', 'XHTML 1.0 Transitional');
+			$config->set('Cache.DefinitionImpl', null);
+			$config->set('Core.EscapeInvalidTags', true);
+
+			// Set allowed html tags (based on stackoverflow whitelist)
+			$config->set(
+				'HTML.Allowed',
+				'a[href|title],b,strong,blockquote[cite],code,del,dd,dl,dt,em,h1,h2,h3,h4,h5,h6,i,li,ol,p,pre,s,sup,sub,strong,strike,ul,br,hr,
+				img[src|alt|title]'
+			);
+
+			$purifier = new HTMLPurifier($config);
+
+			return $purifier->purify($content);
 		}
 
 		return $this->text;


### PR DESCRIPTION
# Problem
On the current Fork CMS forum, there were some problems with [strange symbols in text](http://www.fork-cms.com/community/forum/detail/installing-forkcms-on-centos-6) and codeblocks that get their symbols changed to html entities, making code snippets sometimes unreadable. The old markdownparser was also deprecated. 

# Solution
By upgrading to the new markdownparser, the problem with faulty html encoding,  strange symbols between text and the htmlentities inside code blocks is solved. 

Using html purifier to allow a whitelist of html tags, and escape all the others to avoid XSS, strip "javascript:" commands in anchor tags ([Source](http://stackoverflow.com/a/14914949/1409047)). I used a whitelist of tags similar to the allowed tags on stackoverflow's markdown. HTML or code that is not on the whitelist will get escaped and just gets displayed. 

For example:

* If you type some random code inside your text without defining it as single line or block code in markdown, it will be escaped and displayed (thanks to the EscapeInvalidTags option) like normal text, but it won't run of course.
* Code as block or single line code is displayed like it should be, without some symbols getting changed to the html entities: `<` would change to `&lt;` making the code snippets on the forum unreadable sometimes.
* Symbols like & change to their html entities (&amp;) in normal text, not in code.

I inserted [some XSS](https://github.com/markdown-it/markdown-it/blob/master/test/fixtures/markdown-it/xss.txt) – just to be sure – into a comment and seems to me that in all cases the anchors can't be executed (href removed or escaped)