### PR TITLE
Fix mass actions spam/delete

### DIFF
--- a/backend/modules/forum/actions/index.php
+++ b/backend/modules/forum/actions/index.php
@@ -42,7 +42,7 @@ class BackendForumIndex extends BackendBaseActionIndex
 		$this->dgPublished->setRowAttributes(array('id' => '[id]'));
 
 		// add the multicheckbox column
-		$this->dgPublished->setMassActionCheckboxes('checkbox', '[id]');
+		$this->dgPublished->setMassActionCheckboxes('checkbox', '[type]-[id]');
 
 		// html entities
 		$this->dgPublished->setColumnFunction('htmlentities', '[text]', 'text', true);
@@ -69,7 +69,7 @@ class BackendForumIndex extends BackendBaseActionIndex
 
 		// add extra column for button
 		$this->dgPublished->addColumn('edit', null, BL::lbl('Edit'), BackendModel::createURLForAction('edit_[type]') . '&amp;id=[id]', BL::lbl('Edit'));
-		$this->dgPublished->addColumn('mark_as_spam', null, BL::lbl('MarkAsSpam'), BackendModel::createURLForAction('mass_action') . '&amp;id=[id]&amp;from=published&amp;action=spam', BL::lbl('MarkAsSpam'));
+		$this->dgPublished->addColumn('mark_as_spam', null, BL::lbl('MarkAsSpam'), BackendModel::createURLForAction('mass_action') . '&amp;id=[type]-[id]&amp;from=published&amp;action=spam', BL::lbl('MarkAsSpam'));
 	}
 
 	/**
@@ -81,7 +81,7 @@ class BackendForumIndex extends BackendBaseActionIndex
 		$this->dgSpam->setRowAttributes(array('id' => '[id]'));
 
 		// add the multicheckbox column
-		$this->dgSpam->setMassActionCheckboxes('checkbox', '[id]');
+		$this->dgSpam->setMassActionCheckboxes('checkbox', '[type]-[id]');
 
 		// html entities
 		$this->dgSpam->setColumnFunction('htmlentities', '[text]', 'text', true);
@@ -103,7 +103,7 @@ class BackendForumIndex extends BackendBaseActionIndex
 		$this->dgSpam->setMassAction($ddmMassAction);
 
 		// add extra column for button
-		$this->dgSpam->addColumn('approve', null, BL::lbl('Approve'), BackendModel::createURLForAction('mass_action') . '&amp;id=[id]&amp;from=spam&amp;action=visible', BL::lbl('Approve'));
+		$this->dgSpam->addColumn('approve', null, BL::lbl('Approve'), BackendModel::createURLForAction('mass_action') . '&amp;id=[type]-[id]&amp;from=spam&amp;action=visible', BL::lbl('Approve'));
 	}
 
 	/**

--- a/backend/modules/forum/actions/mass_action.php
+++ b/backend/modules/forum/actions/mass_action.php
@@ -39,7 +39,7 @@ class BackendForumMassAction extends BackendBaseAction
 		if($action == 'delete') BackendForumModel::delete($ids);
 
 		// change statuses
-		else BackendForumModel::updatePostTypes($ids, $action);
+		else BackendForumModel::updateTypes($ids, $action);
 
 		// define report
 		$report = (count($ids) > 1) ? 'items-' : 'item-';

--- a/frontend/modules/forum/actions/detail.php
+++ b/frontend/modules/forum/actions/detail.php
@@ -63,6 +63,11 @@ class FrontendForumDetail extends FrontendBaseBlock
 
 		// anything found?
 		if($this->topic->getTitle() == null) $this->redirect(FrontendNavigation::getURL(404));
+
+        // tagged as a spam topic? Hide it for google
+        if($this->topic->getType() == 'spam') {
+            $this->header->addMetaData(array('name' => 'robots', 'content' => 'noindex, follow'), true);
+        }
 	}
 
 	/**


### PR DESCRIPTION
* Implemented "move to spam" and "delete" mass actions in the backend. They didn't work because topics and posts are displayed mixed together in the datagrid and no distinction was made between them when a backend action executed. I parsed the "type" into the id to make the distinction and made a general "updateType" method that splits the id and execute separate code for the posts and for the topics. 
* Topics tagged as "spam" are still visible in google when you search, so hide them using add noindex, nofollow.